### PR TITLE
Improvements to the atsha204 driver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,33 +1,52 @@
+ifneq ($(KERNELRELEASE),)
+# If KERNELRELEASE is defined then we have been included by the kernel's
+# makefiles and are actually building the module.
+
 obj-m := atsha204-i2c.o
-KDIR ?= /lib/modules/`uname -r`/build
-MDIR ?= /lib/modules/`uname -r`/kernel/drivers/char/
-SRC = atsha204-i2c.c atsha204-i2c.h
-# Enable CFLAG to run DEBUG MODE
+
+# Enable CFLAGS to run DEBUG MODE
 #CFLAGS_atsha204-i2c.o := -DDEBUG
 
-all:
-	make -C $(KDIR) M=$$PWD modules
-#	make testing code
-	gcc -c $$PWD/test/test.c
-	gcc $$PWD/test/test.c -o $$PWD/test/test
+else
+
+# To cross-compile this module invoke make with KDIR set to the kernel directory
+# and KOPTIONS set to the required extra kernel build options, for example:
+#   make KDIR=$MYPROJ/mykernel KOPTIONS="ARCH=arm CROSS_COMPILE=$MYPROJ/toolchain/bin/arm-cortexa5-linux-gnueabihf-"
+
+KDIR ?= /lib/modules/`uname -r`/build
+MDIR ?= /lib/modules/`uname -r`/kernel/drivers/char/
+
+SRC := atsha204-i2c.c atsha204-i2c.h
+MODULE := atsha204-i2c.ko
+
+.PHONY: all module clean install check modules_install
+
+all: module test/test
+
+module:
+	$(MAKE) -C $(KDIR) $(KOPTIONS) M=$(CURDIR) modules
+
+test/test: test/test.c
+	$(CC) $^ -o $@
 
 clean:
-	make -C $(KDIR) M=$$PWD clean
-	-rm -rf $$PWD/test/test.o $$PWD/test/test TAGS
+	$(MAKE) -C $(KDIR) $(KOPTIONS) M=$(CURDIR) clean
+	rm -f test/test TAGS
 
 install:
-	sudo cp atsha204-i2c.ko $(MDIR)
-	-sudo insmod atsha204-i2c.ko
+	sudo cp $(MODULE) $(MDIR)
+	-sudo insmod $(MODULE)
 	-echo atsha204-i2c 0x60 | sudo tee /sys/class/i2c-adapter/i2c-1/new_device
 	sudo chgrp i2c /dev/atsha0
 	sudo chmod 664 /dev/atsha0
-
 
 check:
 	./test/test
 
 modules_install:
-	cp atsha204-i2c.ko $(MDIR)
+	cp $(MODULE) $(MDIR)
 
 TAGS:
 	etags $(SRC)
+
+endif

--- a/atsha204-i2c.c
+++ b/atsha204-i2c.c
@@ -148,7 +148,7 @@ bool atsha204_crc16_matches(const u8 *buf, const u8 len, const u16 crc)
 
 bool atsha204_check_rsp_crc16(const u8 *buf, const u8 len)
 {
-        u16 *rec_crc = &buf[len - 2];
+        const u16 *rec_crc = (const u16 *)&buf[len - 2];
         return atsha204_crc16_matches(buf, len - 2, cpu_to_le16(*rec_crc));
 }
 

--- a/atsha204-i2c.c
+++ b/atsha204-i2c.c
@@ -404,8 +404,8 @@ int atsha204_i2c_release(struct inode *inode, struct file *filep)
 struct atsha204_chip *atsha204_i2c_register_hardware(struct device *dev,
                                                      struct i2c_client *client)
 {
-
         struct atsha204_chip *chip;
+        int rc;
 
         if ((chip = kzalloc(sizeof(*chip), GFP_KERNEL)) == NULL)
                 goto out_null;
@@ -425,11 +425,11 @@ struct atsha204_chip *atsha204_i2c_register_hardware(struct device *dev,
                 dev_err(dev, "%s\n", "Failed to add device");
                 goto put_device;
         }
-        else{
-                int rc = hwrng_register(&atsha204_i2c_rng);
-                dev_dbg(dev, "%s%d\n", "HWRNG result: ", rc);
-        }
 
+        global_chip = chip;
+
+        rc = hwrng_register(&atsha204_i2c_rng);
+        dev_dbg(dev, "%s%d\n", "HWRNG result: ", rc);
 
         return chip;
 

--- a/atsha204-i2c.h
+++ b/atsha204-i2c.h
@@ -21,6 +21,9 @@
 #define ATSHA204_SLEEP 0x01
 #define ATSHA204_RNG_NAME "atsha-rng"
 
+#define ATECC108_W_HI (500)    // 500us for ATECC108A
+#define ATSHA204_W_HI (2500)   // 2.5ms for ATSHA204
+
 struct atsha204_chip {
     struct device *dev;
 


### PR DESCRIPTION
I have been working on a design using the ATECC108A chip, and have found the atsha204 driver very useful for communicating with this chip, but encountered a number of issues. I hope you will find these commits to be useful general improvements to the code.

I am not entirely happy with the method used to wake the chip up, as described in the commit comments, but I can't currently think of a better solution.

Note that I have not tested with ATSHA204, only ATECC108A, but these changes should work with both chips.
